### PR TITLE
patch v2.0.9

### DIFF
--- a/v2/README.md
+++ b/v2/README.md
@@ -31,6 +31,11 @@ Some improvements to check, later:
 Version Changes Control
 =======================
 
+v2.0.9 - 2021-11-25
+-----------------------
+- XCache modified to defer mutex unlocks instead of directly unlock into the code, to avoid dead locks in case of thread panic and crashes.
+- XLanguage modified to defer mutex unlocks instead of directly unlock into the code, to avoid dead locks in case of thread panic and crashes.
+
 v2.0.8 - 2021-05-18
 -----------------------
 - XTemplate is now clonable: newtemplate := template.Clone()

--- a/v2/xcore.go
+++ b/v2/xcore.go
@@ -868,7 +868,7 @@
 package xcore
 
 // VERSION is the used version nombre of the XCore library.
-const VERSION = "2.0.8"
+const VERSION = "2.0.9"
 
 // LOG is the flag to activate logging on the library.
 // if LOG is set to TRUE, LOG indicates to the XCore libraries to log a trace of functions called, with most important parameters.

--- a/v2/xlanguage.go
+++ b/v2/xlanguage.go
@@ -107,10 +107,10 @@ func (l *XLanguage) LoadXMLString(data string) error {
 	l.Name = temp.Name
 	l.Language, _ = language.Parse(temp.Language)
 	l.mutex.Lock()
+	defer l.mutex.Unlock()
 	for _, e := range temp.Entries {
 		l.entries[e.ID] = e.Entry
 	}
-	l.mutex.Unlock()
 	return nil
 }
 
@@ -157,8 +157,8 @@ func (l *XLanguage) LoadString(data string) error {
 			value = strings.TrimSpace(line[posequal+1:])
 		}
 		l.mutex.Lock()
+		defer l.mutex.Unlock()
 		l.entries[key] = value
-		l.mutex.Unlock()
 	}
 	if err := scanner.Err(); err != nil {
 		return err
@@ -189,15 +189,15 @@ func (l *XLanguage) GetLanguage() language.Tag {
 // Set will add an entry id-value into the language table
 func (l *XLanguage) Set(entry string, value string) {
 	l.mutex.Lock()
+	defer l.mutex.Unlock()
 	l.entries[entry] = value
-	l.mutex.Unlock()
 }
 
 // Get will read an entry id-value from the language table
 func (l *XLanguage) Get(entry string) string {
 	l.mutex.RLock()
+	defer l.mutex.RUnlock()
 	v, ok := l.entries[entry]
-	l.mutex.RUnlock()
 	if ok {
 		return v
 	}
@@ -207,18 +207,18 @@ func (l *XLanguage) Get(entry string) string {
 // Del will remove an entry id-value from the language table
 func (l *XLanguage) Del(entry string) {
 	l.mutex.Lock()
+	defer l.mutex.Unlock()
 	delete(l.entries, entry)
-	l.mutex.Unlock()
 }
 
 // GetEntries will return a COPY of the key-values pairs of the language.
 func (l *XLanguage) GetEntries() map[string]string {
 	clone := map[string]string{}
 	l.mutex.RLock()
+	defer l.mutex.RUnlock()
 	for k, v := range l.entries {
 		clone[k] = v
 	}
-	l.mutex.RUnlock()
 	return clone
 }
 
@@ -226,10 +226,10 @@ func (l *XLanguage) GetEntries() map[string]string {
 func (l *XLanguage) String() string {
 	sdata := []string{}
 	l.mutex.RLock()
+	defer l.mutex.RUnlock()
 	for key, val := range l.entries {
 		sdata = append(sdata, key+":"+fmt.Sprintf("%v", val))
 	}
-	l.mutex.RUnlock()
 	sort.Strings(sdata) // Lets be sure the print is always the same presentation
 	return "xcore.XLanguage{" + strings.Join(sdata, " ") + "}"
 }
@@ -238,10 +238,10 @@ func (l *XLanguage) String() string {
 func (l *XLanguage) GoString() string {
 	sdata := []string{}
 	l.mutex.RLock()
+	defer l.mutex.RUnlock()
 	for key, val := range l.entries {
 		sdata = append(sdata, key+":"+fmt.Sprintf("%#v", val))
 	}
-	l.mutex.RUnlock()
 	sort.Strings(sdata) // Lets be sure the print is always the same presentation
 	return "#xcore.XLanguage{" + strings.Join(sdata, " ") + "}"
 }


### PR DESCRIPTION
- XCache modified to defer mutex unlocks instead of directly unlock into the code, to avoid dead locks in case of thread panic and crashes.
- XLanguage modified to defer mutex unlocks instead of directly unlock into the code, to avoid dead locks in case of thread panic and crashes.
