### PR TITLE
patch v2.2.2

### DIFF
--- a/v2/README.md
+++ b/v2/README.md
@@ -31,6 +31,10 @@ Some improvements to check, later:
 Version Changes Control
 =======================
 
+v2.2.2 - 2023-10-12
+-----------------------
+- Added a security on the sub template .none for ?? meta language into XTemplate, to not try to use an inexistant template and throw a panic error.
+
 v2.2.1 - 2023-09-29
 -----------------------
 - Added the missing sub template .none for ?? meta language into XTemplate.

--- a/v2/xcore.go
+++ b/v2/xcore.go
@@ -879,7 +879,7 @@
 package xcore
 
 // VERSION is the used version nombre of the XCore library.
-const VERSION = "2.2.1"
+const VERSION = "2.2.2"
 
 // LOG is the flag to activate logging on the library.
 // if LOG is set to TRUE, LOG indicates to the XCore libraries to log a trace of functions called, with most important parameters.

--- a/v2/xtemplate.go
+++ b/v2/xtemplate.go
@@ -454,8 +454,10 @@ func (t *XTemplate) injector(datacol XDatasetCollectionDef, language *XLanguage)
 				if tmp != nil {
 					subt = tmp
 				}
-				substr := subt.injector(datacol, language)
-				injected = append(injected, substr)
+				if subt != nil {
+					substr := subt.injector(datacol, language)
+					injected = append(injected, substr)
+				}
 			}
 		case MetaDump:
 			if datacol != nil {


### PR DESCRIPTION
v2.2.2 - 2023-10-12
-----------------------
- Added a security on the sub template .none for ?? meta language into XTemplate, to not try to use an inexistant template and throw a panic error.
