### PR TITLE
patch v2.3.0

### DIFF
--- a/v2/README.md
+++ b/v2/README.md
@@ -31,6 +31,14 @@ Some improvements to check, later:
 Version Changes Control
 =======================
 
+v2.3.0 - 2025-10-03
+-----------------------
+- XTemplate has now the ability to use templates from upper levels. Example:
+[[a]]Template A[[]]
+&&b&&
+[[b]] Using template a: &&a&& [[]]
+This will insert the template A into the template B, since template A is accessible for any sub templates. Just be carefull of infinite recursivity.
+
 v2.2.3 - 2025-06-09
 -----------------------
 - Corrected a bug into xtemplate that made the conditional for sub templates with an array of dataset not working

--- a/v2/xcore.go
+++ b/v2/xcore.go
@@ -856,7 +856,7 @@
 package xcore
 
 // VERSION is the used version nombre of the XCore library.
-const VERSION = "2.2.3"
+const VERSION = "2.3.0"
 
 // LOG is the flag to activate logging on the library.
 // if LOG is set to TRUE, LOG indicates to the XCore libraries to log a trace of functions called, with most important parameters.

--- a/v2/xtemplate.go
+++ b/v2/xtemplate.go
@@ -79,6 +79,7 @@ type XTemplate struct {
 	Name         string
 	Root         *XTemplateData
 	SubTemplates map[string]*XTemplate
+	Father       *XTemplate
 	// mutex        sync.RWMutex
 }
 
@@ -276,6 +277,7 @@ func (t *XTemplate) AddTemplate(name string, tmpl *XTemplate) {
 	if t.SubTemplates == nil {
 		t.SubTemplates = make(map[string]*XTemplate)
 	}
+	tmpl.Father = t
 	t.SubTemplates[name] = tmpl
 }
 
@@ -284,7 +286,14 @@ func (t *XTemplate) GetTemplate(name string) *XTemplate {
 	if t.SubTemplates == nil {
 		return nil
 	}
-	return t.SubTemplates[name]
+	tmp := t.SubTemplates[name]
+	if tmp != nil {
+		return tmp
+	}
+	if t.Father != nil {
+		return t.Father.GetTemplate(name)
+	}
+	return nil
 }
 
 // Execute will inject the Data into the template and creates the final string


### PR DESCRIPTION
- XTemplate has now the ability to use templates from upper levels. Example:
[[a]]Template A[[]]
&&b&&
[[b]] Using template a: &&a&& [[]]
This will insert the template A into the template B, since template A is accessible for any sub templates. Just be carefull of infinite recursivity.

