### PR TITLE
patch v2.3.2

### DIFF
--- a/v2/README.md
+++ b/v2/README.md
@@ -31,6 +31,10 @@ Some improvements to check, later:
 Version Changes Control
 =======================
 
+v2.3.2 - 2025-10-06
+-----------------------
+- Added missing Father copy into clonation of object. Added some protections on String and GoString functions for nil pointers.
+
 v2.3.1 - 2025-10-06
 -----------------------
 - Added missing case in template use from upper level. Now working.

--- a/v2/xcore.go
+++ b/v2/xcore.go
@@ -856,7 +856,7 @@
 package xcore
 
 // VERSION is the used version nombre of the XCore library.
-const VERSION = "2.3.1"
+const VERSION = "2.3.2"
 
 // LOG is the flag to activate logging on the library.
 // if LOG is set to TRUE, LOG indicates to the XCore libraries to log a trace of functions called, with most important parameters.

--- a/v2/xtemplate.go
+++ b/v2/xtemplate.go
@@ -494,6 +494,9 @@ func (t *XTemplate) injector(datacol XDatasetCollectionDef, language *XLanguage)
 // String will transform the XDataset into a readable string for humans
 func (t *XTemplate) String() string {
 	sdata := []string{}
+	if t.Root == nil {
+		return "xcore.XTemplate{}"
+	}
 	for _, val := range *t.Root {
 		sdata = append(sdata, fmt.Sprintf("%v", val))
 	}
@@ -504,6 +507,9 @@ func (t *XTemplate) String() string {
 // GoString will transform the XDataset into a readable string for humans with values indexes
 func (t *XTemplate) GoString() string {
 	sdata := []string{}
+	if t.Root == nil {
+		return "#xcore.XTemplate{}"
+	}
 	for _, val := range *t.Root {
 		sdata = append(sdata, fmt.Sprintf("%#v", val))
 	}
@@ -525,9 +531,11 @@ func (t *XTemplate) Clone() *XTemplate {
 		newsubtemplates := map[string]*XTemplate{}
 		for id, xt := range t.SubTemplates {
 			newsubtemplates[id] = xt.Clone()
+			xt.Father = cloned
 		}
 		cloned.SubTemplates = newsubtemplates
 	}
+	cloned.Father = t.Father
 
 	return cloned
 }

--- a/v2/xtemplate_test.go
+++ b/v2/xtemplate_test.go
@@ -238,6 +238,7 @@ func TestXTemplateCall(t *testing.T) {
 	if result != "ABC\nDA\nEAF\n\n" {
 		t.Errorf("The call templates are not called correctly")
 	}
+	fmt.Println(result)
 }
 
 func TestXTemplateSimple(t *testing.T) {


### PR DESCRIPTION
- Added missing Father copy into clonation of object. Added some protections on String and GoString functions for nil pointers.